### PR TITLE
Update to accommodate MMPU

### DIFF
--- a/pmpro-mailchimp.php
+++ b/pmpro-mailchimp.php
@@ -992,7 +992,7 @@ function pmpromc_subscribe($list, $user)
 /**
  * Unsubscribe a user from a specific list
  *
- * @param $list - the List ID
+ * @param $list - the List ID or list object
  * @param $user - The WP_User object for the user
  */
 function pmpromc_unsubscribe($list, $user)
@@ -1004,8 +1004,14 @@ function pmpromc_unsubscribe($list, $user)
     $options = get_option("pmpromc_options");
     $api = pmpromc_getAPI();
 
+	if(is_object($list)) {
+		$listid = $list->id;
+	} else {
+		$listid = $list;
+	}
+
     if ($api) {
-        $api->unsubscribe($list, $user);
+        $api->unsubscribe($listid, $user);
     } else {
         wp_die(__('Error during unsubscribe operation. Please report this error to the administrator', 'pmpromc'));
     }
@@ -1271,7 +1277,7 @@ function pmpromc_pmpro_mailchimp_listsubscribe_fields($fields, $user, $list)
 
     return $fields;
 }
-add_filter('pmpro_mailchimp_listsubscribe_fields', 'pmpromc_pmpro_mailchimp_listsubscribe_fields', 10, 2);
+add_filter('pmpro_mailchimp_listsubscribe_fields', 'pmpromc_pmpro_mailchimp_listsubscribe_fields', 10, 3);
 
 /**
  * Add links to the plugin action links


### PR DESCRIPTION
Five functions were modified:

- pmpromc_sync_merge_fields

Change the call to getMembershipLevelForUser to the plural, and loop
through each level in the check for subscription and adding as needed.

- pmpromc_pmpro_after_checkout

Look for multiple levels on checkout by checking the MMPU-set global
variable, and if it’s there, loop through them to call the
after_change_membership_level for each.

- pmpromc_unsubscribeFromLists

Change the approach here to essentially do a sync instead of trying to
look at the last transaction. Get all the currently-subscribed levels
(it’s updated by now), and users_lists and opt-ins, and exempt those,
but unsub from the rest (unless “all” was chosen).

- pmpromc_pmpro_mailchimp_listsubscribe_fields

We’re passed the list ID into the function now, so we look for all
levels this user is subscribed to that have this list. If there are 0
or 1 levels, it behaves as before. If there are more than 1, the ID and
level name fields are set to a comma-delimited list of the relevant
levels to this list that the user is subscribed to. I’m not sold on the
comma as a delimiter, since level names may have commas in them, but I
also didn’t want to freak out MC.

- pmpromc_subscribe

Minor change to pass the list ID along with the listsubscribe_fields
filter.

Note: This code is not well-tested. Sending it along to diversify testing a bit, but as written, should NOT be used in a production environment.