### PR TITLE
Bug Fix: 401 Invalid API key Fix

### DIFF
--- a/includes/class.mailchimp.api.php
+++ b/includes/class.mailchimp.api.php
@@ -36,7 +36,7 @@ class PMProMailChimp
             $this->url_args = array(
                 'timeout' => apply_filters('pmpro_addon_mc_api_timeout', 10),
                 'headers' => array(
-                    'Authorization' => 'Basic ' . self::$api_key
+                    'Authorization' => 'PMPro_MC ' . self::$api_key
                 ),
             );
 
@@ -83,7 +83,7 @@ class PMProMailChimp
         $this->url_args = array(
             'timeout' => apply_filters('pmpromc_api_timeout', 10),
             'headers' => array(
-                'Authorization' => 'Basic ' . self::$api_key
+                'Authorization' => 'PMPro_MC ' . self::$api_key
             ),
         );
 


### PR DESCRIPTION
Bug Fix: Adjust the Authorization header to change the username from Basic to PMPro_MC to fix false errors.

For some reason when using "Basic" as the username it would cause an error saying the API key is invalid even though it is not.