### PR TITLE
PHP8: Deprecated Notices Fixed

### DIFF
--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -348,7 +348,7 @@ class PMPromc_Mailchimp_API
 	 * @return mixed - Merge field or false
 	 * @since 2.0.0
 	 */
-	public function add_merge_field($merge_field, $type = NULL, $public = false, $list_id)
+	public function add_merge_field($merge_field, $type = NULL, $public = false, $list_id = '' )
 	{
 		///echo "(add merge field: $merge_field)";
 		


### PR DESCRIPTION
PHP8 Deprecated Notices Fixed. It's frowned upon to have an optional variable in a function followed by a required variable. We should either switch them around (not doing this here), or give both variables a default value in the function.

[Errors] Upon activate:

```
[10-Dec-2020 13:45:16 UTC] PHP Deprecated: Required parameter $list_id follows optional parameter $type in /srv/users/phptesting/apps/php8/public/wp-content/plugins/pmpro-mailchimp/classes/class-pmpromc-mailchimp-api.php on line 351
```