### PR TITLE
Deprecating set_user_interest()

### DIFF
--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -454,9 +454,12 @@ class PMPromc_Mailchimp_API
 	 * @return \stdClass() $interestes - Object containing the required Interests settings for MC-API v3.0
 	 *
 	 * @since 2.0.0
+	 * @deprecated TBD
 	 */
-	private function set_user_interest($user, $list_id)
-	{
+	private function set_user_interest($user, $list_id) {
+		// Add deprecation message.
+		_deprecated_function( __METHOD__, 'TBD' );
+
 		$level = pmpro_getMembershipLevelForUser($user->ID);
 		$interests = new stdClass();
 		$interests->id = $level->id;


### PR DESCRIPTION
This method is not called and is not MMPU-compatible. Removing this function makes the rest of the Add On MMPU-compatible.