### PR TITLE
Uses readfile if fpassthru  is not available

### DIFF
--- a/includes/export-csv.php
+++ b/includes/export-csv.php
@@ -397,10 +397,15 @@
 				ini_set('zlib.output_compression', 'Off');
 			}
 
-			// open and send the file contents to the remote location
-			$fh = fopen( $filename, 'rb' );
-			fpassthru($fh);
-			fclose($fh);
+			if( function_exists('fpassthru') ) {
+				// open and send the file contents to the remote location
+				$fh = fopen( $filename, 'rb' );
+				fpassthru($fh);
+				fclose($fh);
+			} else {
+				// use readfile() if fpassthru() is disabled (like on Flywheel Hosted)
+				readfile($filename);
+			}
 
 			// remove the temp file
 			unlink($filename);


### PR DESCRIPTION
In the event of fpassthru not being available, the member export will default to the PHP readfile function instead.

Resolves #125