### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -250,14 +250,14 @@ add_action( 'pmpro_checkout_before_change_membership_level', 'pmpromc_pmpro_chec
  *
  * @param int $user_id of user who checked out.
  */
-function pmpromc_pmpro_after_checkout( $user_id ) {
-	pmpromc_pmpro_after_change_membership_level( $_REQUEST['level'], $user_id );
+function pmpromc_pmpro_after_checkout( $user_id, $order ) {
+	pmpromc_pmpro_after_change_membership_level( $order->membership_id, $user_id );
 	if ( empty( $_REQUEST['additional_lists'] ) ) {
 		$_REQUEST['additional_lists'] = array();
 	}
 	pmpromc_set_user_additional_list_meta( $user_id, $_REQUEST['additional_lists'] );
 }
-add_action( 'pmpro_after_checkout', 'pmpromc_pmpro_after_checkout', 15 );
+add_action( 'pmpro_after_checkout', 'pmpromc_pmpro_after_checkout', 15, 2 );
 
 function pmpromc_log( $entry ) {
 	$options = get_option( 'pmpromc_options' );


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.