### PR TITLE
Scrub email addresses when logging information.

### DIFF
--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -153,6 +153,12 @@ class PMPromc_Mailchimp_API
 		}
 		foreach ( $pmpromc_lists as $audience_arr ) {
 			if ( $audience_arr['id'] == $audience ) {
+				$scrub_log_data = $updates;
+				// Scrub email address from the update data to obfuscate it a bit.
+				if ( ! empty( $scrub_log_data[0]->email_address ) ) {
+					$scrub_log_data[0]->email_address = preg_replace( '/(?<=.).(?=.*@)/u', '*', $scrub_log_data[0]->email_address );
+				}
+
 				pmpromc_log("Processing update for audience {$audience_arr['name']} ({$audience}): " . print_r( $updates, true ) );
 				break;
 			}

--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -159,7 +159,7 @@ class PMPromc_Mailchimp_API
 					$scrub_log_data[0]->email_address = preg_replace( '/(?<=.).(?=.*@)/u', '*', $scrub_log_data[0]->email_address );
 				}
 
-				pmpromc_log("Processing update for audience {$audience_arr['name']} ({$audience}): " . print_r( $updates, true ) );
+				pmpromc_log("Processing update for audience {$audience_arr['name']} ({$audience}): " . print_r( $scrub_log_data, true ) );
 				break;
 			}
 		}


### PR DESCRIPTION
* SECURITY: scrub sensitive information when logging data to the debug log. Emails will now be a***@gmail.com for example.


Notes: Site owners, please delete these files or turn off debug logging when all functionality is working as intended. After updating to the latest plugin version your site will remove the log file and it will be blank.