### PR TITLE
Scrub email addresses in the log file.

### DIFF
--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -153,13 +153,7 @@ class PMPromc_Mailchimp_API
 		}
 		foreach ( $pmpromc_lists as $audience_arr ) {
 			if ( $audience_arr['id'] == $audience ) {
-				$scrub_log_data = $updates;
-				// Scrub email address from the update data to obfuscate it a bit.
-				if ( ! empty( $scrub_log_data[0]->email_address ) ) {
-					$scrub_log_data[0]->email_address = preg_replace( '/(?<=.).(?=.*@)/u', '*', $scrub_log_data[0]->email_address );
-				}
-
-				pmpromc_log("Processing update for audience {$audience_arr['name']} ({$audience}): " . print_r( $scrub_log_data, true ) );
+				pmpromc_log("Processing update for audience {$audience_arr['name']} ({$audience}): " . print_r( $updates, true ) );
 				break;
 			}
 		}

--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -153,6 +153,12 @@ class PMPromc_Mailchimp_API
 		}
 		foreach ( $pmpromc_lists as $audience_arr ) {
 			if ( $audience_arr['id'] == $audience ) {
+				$scrub_log_data = $updates;
+				// Scrub email address from the update data to obfuscate it a bit.
+				if ( ! empty( $scrub_log_data[0]->email_address ) ) {
+					$scrub_log_data[0]->email_address = preg_replace( '/(?<=.).(?=.*@)/u', '*', $scrub_log_data[0]->email_address );
+				}
+
 				pmpromc_log("Processing update for audience {$audience_arr['name']} ({$audience}): " . print_r( $updates, true ) );
 				break;
 			}

--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -159,7 +159,7 @@ class PMPromc_Mailchimp_API
 					$scrub_log_data[0]->email_address = preg_replace( '/(?<=.).(?=.*@)/u', '*', $scrub_log_data[0]->email_address );
 				}
 
-				pmpromc_log("Processing update for audience {$audience_arr['name']} ({$audience}): " . print_r( $updates, true ) );
+				pmpromc_log("Processing update for audience {$audience_arr['name']} ({$audience}): " . print_r( $scrub_log_data, true ) );
 				break;
 			}
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -266,6 +266,10 @@ function pmpromc_log( $entry ) {
 		return;
 	}
 
+	// Define a regular expression pattern to match email addresses
+	$pattern = '/(?<=@)([a-zA-Z0-9._%+-]+)(?=\.[a-zA-Z]{2,})/';
+	$entry = preg_replace( $pattern, '****', $entry );
+
 	$logstr = "Logged On: " . date_i18n("m/d/Y H:i:s") . "\n";
 	$logstr .= $entry;
 	$logstr .= "\n-------------\n";


### PR DESCRIPTION
Scrubs email addresses in the log file which is publicly available if the direct URL is known. The output will be andrew@***.com. This will be easier for site admins to cross-reference between MailChimp and PMPro as doing ****@gmail.com doesn't make sense as gmail is very common. This will always show 3 asterisk to make it hard to guess what the domain could be.

Notes: Site owners should delete this file when not in use, it will automatically be deleted when this Add On is updated. This will look at the entire log file and scrub all instances of emails.