### PR TITLE
Include sync_tags option

### DIFF
--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -170,6 +170,7 @@ class PMPromc_Mailchimp_API
 		$data = (object) array(
 			'members' => $updates,
 			'update_existing' => true,
+			'sync_tags' => true,
 		);
 		$url = self::$api_url . "/lists/{$audience}";
 		$args = array(


### PR DESCRIPTION
Allows users who add tags with the `pmpromc_user_data` filter to also have these tags properly synced by MailChimp. Changes nothing if the users are not adding tags with a filter.

Right now it is possible for users of this add-on to ask MailChimp to include tags by creating a filter like this:

```php
function add_my_tags( $user_data, $user ) {
	$data = get_object_vars( $user_data );
	$data['tags'] = get_my_tags_for_user($user);
	$user_data = (object) $data;
	return $user_data;
}
add_filter('pmpromc_user_data', 'add_my_tags', 10, 2);
```
The problem is that MailChimp will, by default, only _add_ tags to a list member. If a user of this add-on is going to the trouble to add tags at all, then the more likely case is that they intend for MailChimp to _sync_ these tags for the member. In fact this is analogous to the fact that the add-on already assumes we want to _update_ the existing user on line 172. All we are suggesting is that this updating should extend to tags as well, if tags are supplied.

An acceptable alternative would be to provide a filter for the `$data` being created on line 170, but that seems to us to be be overkill in this instance. It is hard to imagine use cases where someone goes to the trouble of specifying tags and does not want them synced.

Note that this, in part, would help satisfy [this enhancement request](https://github.com/strangerstudios/pmpro-mailchimp/issues/110) for users who are comfortable using filters.