### PR TITLE
Add filter for body parameter data

### DIFF
--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -167,10 +167,10 @@ class PMPromc_Mailchimp_API
 			$this->add_pmpro_merge_fields( $audience) ;
 		}
 
-		$data = (object) array(
+		$data = (object) apply_filters( 'pmpromc_body_parameters', array(
 			'members' => $updates,
 			'update_existing' => true,
-		);
+		), $audience );
 		$url = self::$api_url . "/lists/{$audience}";
 		$args = array(
 			'method' => 'POST', // Allows us update a user ID

--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -167,10 +167,21 @@ class PMPromc_Mailchimp_API
 			$this->add_pmpro_merge_fields( $audience) ;
 		}
 
-		$data = (object) apply_filters( 'pmpromc_body_parameters', array(
+		$data = (object) array(
 			'members' => $updates,
 			'update_existing' => true,
-		), $audience );
+		);
+		/**
+		 * Filter the body parameter sent to the "update audience members" endpoint.
+		 *
+		 * @since TBD
+		 *
+		 * @param object $data The data to send to the Mailchimp API.
+		 * @param string $audience The audience ID being updated.
+		 *
+		 * @return object The data to send to the Mailchimp API.
+		 */
+		$data = apply_filters( 'pmpromc_update_audience_members_data', $data, $audience );
 		$url = self::$api_url . "/lists/{$audience}";
 		$args = array(
 			'method' => 'POST', // Allows us update a user ID


### PR DESCRIPTION
Sometimes a user of the add-on may need to modify the body parameters of the MailChimp API call. In our case, we need to do this because we are passing along tags to MailChimp and we want these tags to replace any tags already existing on MailChimp. The API allows for this with the `sync_tags` body parameter, but currently the add-on does not include that parameter. This filter allows us to add the `sync_tags` parameter when needed.

With this commit in place we can do the following:

```php
/* Add our local tags to each user */
function add_my_tags( $user_data, $user ) {
    $data = get_object_vars( $user_data );
    $data['tags'] = get_my_tags_for_user($user);
    $user_data = (object) $data;
    return $user_data;
}
add_filter('pmpromc_user_data', 'add_my_tags', 10, 2);

/* Make sure that MailChimp will replace its tags with the ones we are sending */
public function sync_my_tags( $data, $audience ) {
    $data['sync_tags'] = true;
    return $data;
}
add_filter('pmpromc_body_parameters', 'sync_my_tags', 10, 2);
```

Without the `sync_tags` parameter MailChimp will, by default, only _add_ tags to a list member. With this change we can ask MailChimp to _sync_ these tags for the member. Others may think of further uses for this new filter.

Note that this, in part, would help satisfy [this enhancement request](https://github.com/strangerstudios/pmpro-mailchimp/issues/110) for users who are comfortable using filters.