### PR TITLE
Adding random suffix to log file name

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -273,7 +273,30 @@ function pmpromc_log( $entry ) {
 	$logstr = "Logged On: " . date_i18n("m/d/Y H:i:s") . "\n";
 	$logstr .= $entry;
 	$logstr .= "\n-------------\n";
-	
+
+	$loghandle = fopen( pmpromc_get_log_file_path(), "a+" );
+	fwrite($loghandle, $logstr);
+	fclose($loghandle);
+}
+
+/**
+ * Get the file path for the debug log file.
+ *
+ * @since TBD
+ *
+ * @return string
+ */
+function pmpromc_get_log_file_path() {
+	// Check if we have a unique file name saved already.
+	$pmpromc_file_name = get_option( 'pmpromc_log_file_name' );
+	if ( empty( $pmpromc_file_name ) ) {
+		$pmpromc_file_name = 'pmpromc-log-' . uniqid() . '.txt';
+		update_option( 'pmpromc_log_file_name', $pmpromc_file_name );
+	}
+
+	// Build the debug log file path.
+	$pmpromc_log_path = PMPROMC_DIR . "/logs/" . $pmpromc_file_name;
+
 	/**
 	 * Filter the debug log file path. 
 	 * By default this points to /plugins/pmpro-mailchimp/logs/pmpromc-log.txt
@@ -281,12 +304,9 @@ function pmpromc_log( $entry ) {
 	 * @param string $path
 	 *
 	 * @since 2.3.3
-	 *		 
 	 */
-	$pmpromc_log_path = apply_filters( 'pmpromc_log_path', PMPROMC_DIR . "/logs/pmpromc-log.txt" );
+	$pmpromc_log_path = apply_filters( 'pmpromc_log_path', $pmpromc_log_path );
 
-	$loghandle = fopen( $pmpromc_log_path, "a+" );
-	fwrite($loghandle, $logstr);
-	fclose($loghandle);
+	return $pmpromc_log_path;
 }
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -367,7 +367,7 @@ function pmpromc_option_logging_enabled() {
 		<option value="0" <?php selected( $logging_enabled, 0 ); ?>><?php esc_html_e( 'No', 'pmpro-mailchimp' ); ?></option>
 		<option value="1" <?php selected( $logging_enabled, 1 ); ?>><?php esc_html_e( 'Yes', 'pmpro-mailchimp' ); ?></option>
 	</select>
-	<p class="description"><?php printf( esc_html__( "Debug log can be found at %s", 'pmpro-mailchimp' ), '<code>/wp-content/plugins/pmpro-mailchimp/logs/pmpromc-log.txt</code>' ); ?>
+	<p class="description"><?php printf( esc_html__( "Debug log can be found at %s", 'pmpro-mailchimp' ), '<code>' . esc_html( pmpromc_get_log_file_path() ) . '</code>' ); ?>
 	</p>
 	<?php
 }


### PR DESCRIPTION
Currently, log files can be directly accessed at `somesite.com/wp-content/plugins/pmpro-mailchimp/logs/pmpromc-log.txt`. This PR adds a suffix to `pmpromc-log.txt` to help prevent that data from being found.

A blank index.php file is also added to prevent the `pmpro-mailchimp/logs/` directory listing from being shown.