### PR TITLE
Fixing CSV export sql syntax

### DIFF
--- a/includes/export-csv.php
+++ b/includes/export-csv.php
@@ -116,7 +116,7 @@
 
 	//get users
 	$sqlQuery = "
-		SELECT DISTINCT u.ID,
+		SELECT DISTINCT u.ID
 		FROM {$wpdb->users} u
 			LEFT JOIN {$wpdb->pmpro_memberships_users} mu ON u.ID = mu.user_id
 			LEFT JOIN {$wpdb->pmpro_membership_levels} m ON mu.membership_id = m.id			


### PR DESCRIPTION
Fixing error:

> [11-Apr-2024 14:24:08 UTC] WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FROM wp_users u
			LEFT JOIN wp_pmpro_memberships_users mu ON u.ID = mu.user_id
' at line 2 for query 
		SELECT DISTINCT u.ID,
		FROM wp_users u
			LEFT JOIN wp_pmpro_memberships_users mu ON u.ID = mu.user_id
			LEFT JOIN wp_pmpro_membership_levels m ON mu.membership_id = m.id			
		WHERE mu.membership_id > 0
			AND mu.status = 'active' 
			AND mu.membership_id = 1
		ORDER BY u.ID  made by do_action('wp_ajax_pmpro_mailchimp_export_csv'), WP_Hook->do_action, WP_Hook->apply_filters, pmpromv_wp_ajax_pmpro_mailchimp_export_csv, require_once('/plugins/pmpro-mailchimp/includes/export-csv.php')