### PR TITLE
Update appropriate audiences only on profile update

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -222,8 +222,6 @@ function pmpromc_profile_update( $user_id, $old_user_data ) {
 			// Execute changes that are already queued.
 			pmpromc_process_audience_member_updates_queue();
 
-			$options = get_option( 'pmpromc_options' );
-
 			// Find audience ids associated with the user.
 			$user_audience_ids = array();
 

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -239,6 +239,13 @@ function pmpromc_profile_update( $user_id, $old_user_data ) {
 			}
 		}
 
+		// Include opt-in audiences the user is subscribed to.
+		$user_additional_lists = get_user_meta( $user_id, 'pmpromc_additional_lists', true );
+		if ( ! empty( $user_additional_lists ) ) {
+			$user_audience_ids = array_merge( $user_audience_ids, $user_additional_lists );
+		}
+		$user_audience_ids = array_unique( $user_audience_ids );
+
 		// No audiences to check, bail.
 		if ( empty( $user_audience_ids ) ) {
 			return;

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -215,89 +215,92 @@ function pmpromc_profile_update( $user_id, $old_user_data ) {
 			return;
 		}
 
+		// Execute changes that are already queued.
+		pmpromc_process_audience_member_updates_queue();
+
+		// Find audience ids associated with the user.
+		$user_audience_ids = array();
+
+		// Get membership levels for the user.
+		$user_levels = pmpro_getMembershipLevelsForUser( $user_id );
+
+		if ( ! empty( $user_levels ) ) {
+			// Get audience ids associated with the user's membership levels.
+			foreach ( $user_levels as $level ) {
+				if ( ! empty( $options[ 'level_' . $level->id . '_lists' ] ) ) {
+					$user_audience_ids = array_merge( $user_audience_ids, $options[ 'level_' . $level->id . '_lists' ] );
+				}
+			}
+			$user_audience_ids = array_unique( $user_audience_ids );
+		} else {
+			// Not a member of any levels, get audience ids for non-member lists.
+			if ( ! empty( $options['users_lists'] ) ) {
+				$user_audience_ids = $options['users_lists'];
+			}
+		}
+
+		// No audiences to check, bail.
+		if ( empty( $user_audience_ids ) ) {
+			return;
+		}
+
 		// Get all audiences.
 		$audiences = $api->get_all_lists();
 
 		if ( ! empty( $audiences ) ) {
-			// Execute changes that are already queued.
-			pmpromc_process_audience_member_updates_queue();
-
-			// Find audience ids associated with the user.
-			$user_audience_ids = array();
-
-			// Get membership levels for the user.
-			$user_levels = pmpro_getMembershipLevelsForUser( $user_id );
-
-			if ( ! empty( $user_levels ) ) {
-				// Get audience ids associated with the user's membership levels.
-				foreach ( $user_levels as $level ) {
-					if ( ! empty( $options[ 'level_' . $level->id . '_lists' ] ) ) {
-						$user_audience_ids = array_merge( $user_audience_ids, $options[ 'level_' . $level->id . '_lists' ] );
-					}
+			// Filter out audiences that are not associated with the user.
+			$audiences = array_filter(
+				$audiences,
+				function( $audience ) use ( $user_audience_ids ) {
+					return in_array( $audience->id, $user_audience_ids );
 				}
-				$user_audience_ids = array_unique( $user_audience_ids );
-			} else {
-				// Not a member of any levels, get audience ids for non-member lists.
-				if ( ! empty( $options['users_lists'] ) ) {
-					$user_audience_ids = $options['users_lists'];
-				}
-			}
+			);
 
-			if ( ! empty( $user_audience_ids ) ) {
-				// Filter out audiences that are not associated with the user.
-				$audiences = array_filter(
-					$audiences,
-					function( $audience ) use ( $user_audience_ids ) {
-						return in_array( $audience->id, $user_audience_ids );
-					}
-				);
-
-				foreach ( $audiences as $audience ) {
-					// Check for member.
-					$member = $api->get_listinfo_for_member( $audience->id, $old_user_data );
-					if ( isset( $member->status ) ) {
-						global $pmpromc_audience_member_updates;
-						if ( $email_changed ) {
-							// Update the email.
-							$data = array(
-								'email_address' => $new_user_data->user_email,
-							);
-							if ( WP_DEBUG ) {
-								error_log( "Updating user's email address from {$old_user_data->user_email} to {$new_user_data->user_email} for audience {$audience->name} ({$audience->id})." );
-							}
-							$update_successful = $api->update_contact( $member, $data );
-							if ( ! $update_successful ) {
-								// User's new email may already existed in audience.
-								// Unsubscribe old email address to be sure that it does not recieve emails.
-								if ( WP_DEBUG ) {
-									error_log( "Handling error by unsubscribing {$old_user_data->user_email} from audience {$audience->name} ({$audience->id})." );
-								}
-								$user_data = (object) array(
-									'email_address' => $old_user_data->user_email,
-									'status'        => 'unsubscribed',
-									'merge_fields'  => apply_filters(
-										'pmpro_mailchimp_listsubscribe_fields',
-										array(
-											'FNAME' => wp_specialchars_decode( $new_user_data->first_name ),
-											'LNAME' => wp_specialchars_decode( $new_user_data->last_name ),
-										),
-										$new_user_data,
-										$audience->id
-									),
-								);
-								if ( empty( $pmpromc_audience_member_updates ) ) {
-									$pmpromc_audience_member_updates = array();
-								}
-								if ( ! array_key_exists( $audience->id, $pmpromc_audience_member_updates ) ) {
-									$pmpromc_audience_member_updates[ $audience->id ] = array();
-								}
-								// Use user_id '0' to fake a user.
-								$pmpromc_audience_member_updates[ $audience->id ][0] = $user_data;
-							}
+			foreach ( $audiences as $audience ) {
+				// Check for member.
+				$member = $api->get_listinfo_for_member( $audience->id, $old_user_data );
+				if ( isset( $member->status ) ) {
+					global $pmpromc_audience_member_updates;
+					if ( $email_changed ) {
+						// Update the email.
+						$data = array(
+							'email_address' => $new_user_data->user_email,
+						);
+						if ( WP_DEBUG ) {
+							error_log( "Updating user's email address from {$old_user_data->user_email} to {$new_user_data->user_email} for audience {$audience->name} ({$audience->id})." );
 						}
-						// Update the user's merge fields.
-						pmpromc_add_audience_member_update( $user_id, $audience->id, $member->status );
+						$update_successful = $api->update_contact( $member, $data );
+						if ( ! $update_successful ) {
+							// User's new email may already existed in audience.
+							// Unsubscribe old email address to be sure that it does not recieve emails.
+							if ( WP_DEBUG ) {
+								error_log( "Handling error by unsubscribing {$old_user_data->user_email} from audience {$audience->name} ({$audience->id})." );
+							}
+							$user_data = (object) array(
+								'email_address' => $old_user_data->user_email,
+								'status'        => 'unsubscribed',
+								'merge_fields'  => apply_filters(
+									'pmpro_mailchimp_listsubscribe_fields',
+									array(
+										'FNAME' => wp_specialchars_decode( $new_user_data->first_name ),
+										'LNAME' => wp_specialchars_decode( $new_user_data->last_name ),
+									),
+									$new_user_data,
+									$audience->id
+								),
+							);
+							if ( empty( $pmpromc_audience_member_updates ) ) {
+								$pmpromc_audience_member_updates = array();
+							}
+							if ( ! array_key_exists( $audience->id, $pmpromc_audience_member_updates ) ) {
+								$pmpromc_audience_member_updates[ $audience->id ] = array();
+							}
+							// Use user_id '0' to fake a user.
+							$pmpromc_audience_member_updates[ $audience->id ][0] = $user_data;
+						}
 					}
+					// Update the user's merge fields.
+					pmpromc_add_audience_member_update( $user_id, $audience->id, $member->status );
 				}
 			}
 		}

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -230,7 +230,7 @@ function pmpromc_profile_update( $user_id, $old_user_data ) {
 			// Get membership levels for the user.
 			$user_levels = pmpro_getMembershipLevelsForUser( $user_id );
 
-			if( ! empty( $user_levels ) ) {
+			if ( ! empty( $user_levels ) ) {
 				// Get audience ids associated with the user's membership levels.
 				foreach ( $user_levels as $level ) {
 					if ( ! empty( $options[ 'level_' . $level->id . '_lists' ] ) ) {
@@ -244,7 +244,7 @@ function pmpromc_profile_update( $user_id, $old_user_data ) {
 				}
 			}
 
-			if( ! empty( $user_audience_ids ) ) {
+			if ( ! empty( $user_audience_ids ) ) {
 				// Filter out audiences that are not associated with the user.
 				$audiences = array_filter(
 					$audiences,

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -237,6 +237,7 @@ function pmpromc_profile_update( $user_id, $old_user_data ) {
 						$user_audience_ids = array_merge( $user_audience_ids, $options[ 'level_' . $level->id . '_lists' ] );
 					}
 				}
+				$user_audience_ids = array_unique( $user_audience_ids );
 			} else {
 				// Not a member of any levels, get audience ids for non-member lists.
 				if ( ! empty( $options['users_lists'] ) ) {

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -219,58 +219,89 @@ function pmpromc_profile_update( $user_id, $old_user_data ) {
 		$audiences = $api->get_all_lists();
 
 		if ( ! empty( $audiences ) ) {
+			// Execute changes that are already queued.
 			pmpromc_process_audience_member_updates_queue();
 
-			// Execute changes that are already queued.
-			foreach ( $audiences as $audience ) {
-				// Check for member.
-				$member = $api->get_listinfo_for_member( $audience->id, $old_user_data );
-				if ( isset( $member->status ) ) {
-					global $pmpromc_audience_member_updates;
-					if ( $email_changed ) {
-						// Update the email.
-						$data = array(
-							'email_address' => $new_user_data->user_email,
-						);
-						if ( WP_DEBUG ) {
-							error_log( "Updating user's email address from {$old_user_data->user_email} to {$new_user_data->user_email} for audience {$audience->name} ({$audience->id})." );
-						}
-						$update_successful = $api->update_contact( $member, $data );
-						if ( ! $update_successful ) {
-							// User's new email may already existed in audience.
-							// Unsubscribe old email address to be sure that it does not recieve emails.
-							if ( WP_DEBUG ) {
-								error_log( "Handling error by unsubscribing {$old_user_data->user_email} from audience {$audience->name} ({$audience->id})." );
-							}
-							$user_data = (object) array(
-								'email_address' => $old_user_data->user_email,
-								'status'        => 'unsubscribed',
-								'merge_fields'  => apply_filters(
-									'pmpro_mailchimp_listsubscribe_fields',
-									array(
-										'FNAME' => wp_specialchars_decode( $new_user_data->first_name ),
-										'LNAME' => wp_specialchars_decode( $new_user_data->last_name ),
-									),
-									$new_user_data,
-									$audience->id
-								),
-							);
-							if ( empty( $pmpromc_audience_member_updates ) ) {
-								$pmpromc_audience_member_updates = array();
-							}
-							if ( ! array_key_exists( $audience->id, $pmpromc_audience_member_updates ) ) {
-								$pmpromc_audience_member_updates[ $audience->id ] = array();
-							}
-							// Use user_id '0' to fake a user.
-							$pmpromc_audience_member_updates[ $audience->id ][0] = $user_data;
-						}
+			$options = get_option( 'pmpromc_options' );
+
+			// Find audience ids associated with the user.
+			$user_audience_ids = array();
+
+			// Get membership levels for the user.
+			$user_levels = pmpro_getMembershipLevelsForUser( $user_id );
+
+			if( ! empty( $user_levels ) ) {
+				// Get audience ids associated with the user's membership levels.
+				foreach ( $user_levels as $level ) {
+					if ( ! empty( $options[ 'level_' . $level->id . '_lists' ] ) ) {
+						$user_audience_ids = array_merge( $user_audience_ids, $options[ 'level_' . $level->id . '_lists' ] );
 					}
-					// Update the user's merge fields.
-					pmpromc_add_audience_member_update( $user_id, $audience->id, $member->status );
+				}
+			} else {
+				// Not a member of any levels, get audience ids for non-member lists.
+				if ( ! empty( $options['users_lists'] ) ) {
+					$user_audience_ids = $options['users_lists'];
+				}
+			}
+
+			if( ! empty( $user_audience_ids ) ) {
+				// Filter out audiences that are not associated with the user.
+				$audiences = array_filter(
+					$audiences,
+					function( $audience ) use ( $user_audience_ids ) {
+						return in_array( $audience->id, $user_audience_ids );
+					}
+				);
+
+				foreach ( $audiences as $audience ) {
+					// Check for member.
+					$member = $api->get_listinfo_for_member( $audience->id, $old_user_data );
+					if ( isset( $member->status ) ) {
+						global $pmpromc_audience_member_updates;
+						if ( $email_changed ) {
+							// Update the email.
+							$data = array(
+								'email_address' => $new_user_data->user_email,
+							);
+							if ( WP_DEBUG ) {
+								error_log( "Updating user's email address from {$old_user_data->user_email} to {$new_user_data->user_email} for audience {$audience->name} ({$audience->id})." );
+							}
+							$update_successful = $api->update_contact( $member, $data );
+							if ( ! $update_successful ) {
+								// User's new email may already existed in audience.
+								// Unsubscribe old email address to be sure that it does not recieve emails.
+								if ( WP_DEBUG ) {
+									error_log( "Handling error by unsubscribing {$old_user_data->user_email} from audience {$audience->name} ({$audience->id})." );
+								}
+								$user_data = (object) array(
+									'email_address' => $old_user_data->user_email,
+									'status'        => 'unsubscribed',
+									'merge_fields'  => apply_filters(
+										'pmpro_mailchimp_listsubscribe_fields',
+										array(
+											'FNAME' => wp_specialchars_decode( $new_user_data->first_name ),
+											'LNAME' => wp_specialchars_decode( $new_user_data->last_name ),
+										),
+										$new_user_data,
+										$audience->id
+									),
+								);
+								if ( empty( $pmpromc_audience_member_updates ) ) {
+									$pmpromc_audience_member_updates = array();
+								}
+								if ( ! array_key_exists( $audience->id, $pmpromc_audience_member_updates ) ) {
+									$pmpromc_audience_member_updates[ $audience->id ] = array();
+								}
+								// Use user_id '0' to fake a user.
+								$pmpromc_audience_member_updates[ $audience->id ][0] = $user_data;
+							}
+						}
+						// Update the user's merge fields.
+						pmpromc_add_audience_member_update( $user_id, $audience->id, $member->status );
+					}
 				}
 			}
 		}
 	}
 }
 add_action( 'profile_update', 'pmpromc_profile_update', 20, 2 );
-


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-mailchimp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-mailchimp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently, if the Add On is configured to _update on profile save_, on profile save, merge fields are overwritten for all audiences on the connected Mailchimp account. This leads to unnecessary API calls.

This PR resolves #83

The PR also stops merge fields eg. `PMPLEVEL`, `PMPLEVELID`, etc. being overwritten if the Add On is used on multiple sites with the same Mailchimp account, _provided the sites use separate audiences_. See #124

### How to test the changes in this Pull Request:
1. Enable logging of API calls.
2. Navigate to a user's profile page and click on _Update User_.
3. Check API logs.
4. Apply PR.
5. Navigate to a user's profile page and click on _Update User_.
6. Check API logs.
7. Observe that API calls are now made for applicable audiences only.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->