### PR TITLE
Notify WP debug log when a Mailchimp API call returns an error

### DIFF
--- a/classes/class-pmpromc-mailchimp-api.php
+++ b/classes/class-pmpromc-mailchimp-api.php
@@ -202,6 +202,9 @@ class PMPromc_Mailchimp_API
 		if ( 200 !== wp_remote_retrieve_response_code( $resp ) ) {
 			$this->set_error_msg($resp);
 			pmpromc_log("Mailchimp Error: Response object: " . print_r($resp, true));
+			if ( WP_DEBUG ) {
+				error_log( __( 'An error occurred while contacting Mailchimp. Please see the PMPro Mailchimp log for more information.', 'pmpro-mailchimp' ) );
+			}
 			return false;
 		}
 
@@ -210,6 +213,9 @@ class PMPromc_Mailchimp_API
 			pmpromc_log( 'Mailchimp Response: No errors detected.' );
 		} else {
 			pmpromc_log( 'Mailchimp Response: ' . $response_body->error_count . ' error(s). ' . print_r( $response_body->errors, true ) );
+			if ( WP_DEBUG ) {
+				error_log( __( 'An error occurred while contacting Mailchimp. Please see the PMPro Mailchimp log for more information.', 'pmpro-mailchimp' ) );
+			}
 		}
 		return true;
 	}
@@ -572,6 +578,9 @@ class PMPromc_Mailchimp_API
 		} else {
 			$response_body = self::decode_response( $response['body'] );
 			pmpromc_log( 'Mailchimp Response: Error status ' . $response_body->status . '. ' . print_r( $response_body->errors, true ) );
+			if ( WP_DEBUG ) {
+				error_log( __( 'An error occurred while contacting Mailchimp. Please see the PMPro Mailchimp log for more information.', 'pmpro-mailchimp' ) );
+			}
 		}
 
 		//check response


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-mailchimp/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-mailchimp/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adds an entry in the WP debug log when a PMPro Mailchimp API call returns an error.

Resolves #122

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
