### PR TITLE
BUG FIX: Archive expired members to allow API resubscription

### DIFF
--- a/includes/api-wrapper.php
+++ b/includes/api-wrapper.php
@@ -65,6 +65,16 @@ function pmpromc_queue_unsubscription( $user, $audiences ) {
 }
 
 /**
+ * Archive a user from a specific list (used for expired members to allow future resubscription)
+ *
+ * @param WP_User|int  $user - The WP_User object or user_id for the user.
+ * @param Array|string $audiences - The id(s) of the audience(s) to archive the user from.
+ */
+function pmpromc_queue_archive( $user, $audiences ) {
+	pmpromc_add_audience_member_update( $user, $audiences, 'archived' );
+}
+
+/**
  * Queue an update to an audience
  *
  * @param WP_User|int  $user - The WP_User object or user_id for the user to be updated.
@@ -78,7 +88,7 @@ function pmpromc_add_audience_member_update( $user, $audiences, $status = 'subsc
 	}
 
 	// Check for valid status.
-	if ( ! in_array( $status, array( 'subscribed', 'unsubscribed', 'pending' ), true ) ) {
+	if ( ! in_array( $status, array( 'subscribed', 'unsubscribed', 'pending', 'archived' ), true ) ) {
 		return;
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -68,13 +68,29 @@ function pmpromc_pmpro_after_change_membership_level( $level_id, $user_id ) {
 		}
 	}
 
-	// Calculate unsubscribe audiences.
+	// Calculate unsubscribe and archive audiences.
+	$archive_audiences = array();
 	if ( $options['unsubscribe'] != '0' ) {
-		// Get levels in (admin_changed, inactive, changed) status with modified dates within the past few minutes.
 		global $wpdb;
-		$levels_unsubscribing_from = $wpdb->get_col( 
+
+		// Get expired levels (involuntary) - these will be archived to allow future resubscription
+		$levels_to_archive = $wpdb->get_col(
 			$wpdb->prepare(
-				"SELECT DISTINCT(membership_id) FROM $wpdb->pmpro_memberships_users WHERE user_id = %d AND membership_id NOT IN(%s) AND status IN('admin_changed', 'admin_cancelled', 'cancelled', 'changed', 'expired', 'inactive') AND modified > NOW() - INTERVAL 15 MINUTE ",
+				"SELECT DISTINCT(membership_id) FROM $wpdb->pmpro_memberships_users WHERE user_id = %d AND membership_id NOT IN(%s) AND status IN('expired', 'inactive') AND modified > NOW() - INTERVAL 15 MINUTE ",
+				$user_id,
+				implode(',', $user_level_ids)
+			)
+		);
+		foreach ( $levels_to_archive as $archive_level_id ) {
+			if ( ! empty( $options[ 'level_' . $archive_level_id . '_lists' ] ) ) {
+				$archive_audiences = array_merge( $archive_audiences, $options[ 'level_' . $archive_level_id . '_lists' ] );
+			}
+		}
+
+		// Get cancelled levels (voluntary) - these will be unsubscribed
+		$levels_unsubscribing_from = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT(membership_id) FROM $wpdb->pmpro_memberships_users WHERE user_id = %d AND membership_id NOT IN(%s) AND status IN('admin_changed', 'admin_cancelled', 'cancelled', 'changed') AND modified > NOW() - INTERVAL 15 MINUTE ",
 				$user_id,
 				implode(',', $user_level_ids)
 			)
@@ -107,10 +123,12 @@ function pmpromc_pmpro_after_change_membership_level( $level_id, $user_id ) {
 
 	$subscribe_audiences   = array_unique( $subscribe_audiences );
 	$unsubscribe_audiences = array_unique( $unsubscribe_audiences );
+	$archive_audiences     = array_unique( $archive_audiences );
 
-	// Subscribe/Unsubscribe user.
+	// Subscribe/Unsubscribe/Archive user.
 	pmpromc_queue_subscription( $user_id, $subscribe_audiences );
 	pmpromc_queue_unsubscription( $user_id, array_diff( $unsubscribe_audiences, $subscribe_audiences ) );
+	pmpromc_queue_archive( $user_id, array_diff( $archive_audiences, $subscribe_audiences ) );
 
 	// Update opt-in audiences and user audiences.
 	if ( empty( $user_level_ids ) && 'all' === $options['unsubscribe'] ) {


### PR DESCRIPTION
Fixes #151

## Summary

When a member whose level has previously expired renews, Mailchimp's batch API silently ignores the resubscription request because the contact is in `unsubscribed` status. Mailchimp treats `unsubscribed` as a compliance state that can only be changed by the member themselves, not via API.

This PR fixes the issue by using `archived` status for expired/inactive members (involuntary loss of membership) instead of `unsubscribed`. This allows the API to resubscribe them when they renew. Voluntary cancellations still use `unsubscribed` as expected.

## Changes

1. **Added `archived` status support**
   - Updated `pmpromc_add_audience_member_update()` to accept `'archived'` as a valid status
   - Added new `pmpromc_queue_archive()` function

2. **Split membership status handling**
   - Separated expired/inactive members (involuntary) from cancelled members (voluntary)
   - Expired/inactive → archived (allows future API resubscription)
   - Cancelled/admin_cancelled → unsubscribed (maintains compliance intent)

3. **Updated the level change handler**
   - `pmpromc_pmpro_after_change_membership_level()` now queries and processes expired vs cancelled levels separately
   - Calls appropriate queue function based on membership status

## Testing

To test this fix:

1. Set up a test site with PMPro and Mailchimp integration
2. Create a member with a level that will expire (not cancel)
3. Let the membership expire — verify the member is archived in Mailchimp (not unsubscribed)
4. Renew the membership for the same level
5. Verify the member is resubscribed in Mailchimp

Expected: After renewal, the member should be subscribed in Mailchimp with correct level merge fields.

## Notes

- This only affects members whose levels expire or become inactive (involuntary)
- Voluntary cancellations (cancelled, admin_cancelled) still use `unsubscribed` status
- Existing unsubscribed members in Mailchimp are not affected by this PR — they would need manual resubscription or use of the individual member API endpoint

🪨 Generated with Claude Sonnet 4.5